### PR TITLE
Copy RDS tags to snapshots

### DIFF
--- a/cloudformation/lib/db.js
+++ b/cloudformation/lib/db.js
@@ -61,6 +61,7 @@ export default {
                 Engine: 'postgres',
                 AllowMajorVersionUpgrade: false,
                 DBName: 'tak_ps_forum',
+                CopyTagsToSnapshot: true,
                 DBInstanceIdentifier: cf.stackName,
                 MonitoringInterval: 60,
                 MonitoringRoleArn: cf.getAtt('DBMonitoringRole', 'Arn'),


### PR DESCRIPTION
### Context

A billing audit revealed that RDS Snapshots were not being assigned their parent tags, resulting in unprovisioned billing. This PR adds a copy-to-snapshot: true flag to ensure billing tags are present on automatically created snapshots
